### PR TITLE
Refactoring to avoid librosa specshow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,17 @@ dependencies = [
 test = "pytest {args:tests}"
 test-cov = "pytest --cov {args:tests}"
 
-
 [tool.ruff.lint.extend-per-file-ignores]
 "src/audio_classifier_visualizer/main.py"= ["T201"]
 "tests/*" = ["T201"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "pkg/*.py",
+  "/tests",
+]
+exclude = [
+  "*.json",
+  "pkg/_compat.py",
+  "/notebooks"
+]

--- a/src/audio_classifier_visualizer/audio_file_visualizer.py
+++ b/src/audio_classifier_visualizer/audio_file_visualizer.py
@@ -14,6 +14,229 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 
+class _SpectrogramComponent:
+    def __init__(
+        self,
+        y: np.ndarray,
+        sr: int,
+        class_probabilities: torch.Tensor | None = None,
+        feature_rate: float | None = None,
+        target_class: int | None = None,
+        n_fft: int = 2048,
+        hop_length: int | None = None,
+        colormap: str = "bright",
+        log_scale: bool = False,  # noqa: FBT001 FBT002
+        try_per_channel_normalization: bool = True,  # noqa: FBT001 FBT002
+        clip_outliers: bool = True,  # noqa: FBT001 FBT002
+        labels: list[Any] | None = None,
+        negative_labels: list[Any] | None = None,
+    ):
+        self.audio = y
+        self.sr = sr
+        self.class_probabilities = class_probabilities
+        self.feature_rate = feature_rate if feature_rate is not None else sr // 320
+        self.target_class = target_class
+        self.n_fft = n_fft
+        self.hop_length = hop_length
+        self.colormap = colormap
+        self.log_scale = log_scale
+        self.try_per_channel_normalization = try_per_channel_normalization
+        self.clip_outliers = clip_outliers
+
+        # TODO: single array of labels of many classes
+        self.labels = labels
+        self.negative_labels = negative_labels
+
+        self.similarity_scores = class_probabilities.cpu()[:, 1]
+        self.dissimilarity_scores = class_probabilities.cpu()[:, 0]
+
+        self.duration = self.audio.shape[0] / self.sr
+        self.spec = librosa.stft(self.audio, n_fft=self.n_fft, win_length=self.n_fft, hop_length=self.hop_length)
+        self.freqs = librosa.fft_frequencies(sr=self.sr, n_fft=self.n_fft)
+        self.spectral_power = np.abs(self.spec) ** 2  # type: ignore
+        # This component shouldn't care much about absolute times, except for adding labels
+        self.start_time = 0
+        self.end_time = self.audio.shape[0] / self.sr
+
+    def time_to_score_index(self, t: float) -> int:
+        return t * self.feature_rate
+
+    def score_index_to_time(self, s: int) -> float:
+        return s / self.feature_rate
+
+    def interpolate_1d_tensor(self, input_tensor: torch.Tensor, target_length: int) -> torch.Tensor:
+        z = input_tensor[None, None, :]
+        return torch.nn.functional.interpolate(z, target_length)[0][0]
+
+    def add_annotation_boxes(
+        self,
+        labels: list[Any],
+        patch_start: float,
+        patch_end: float,
+        axarr: Axes,
+        offset: float = 0.2,
+        color: tuple[float, float, float] = (0.0, 1.0, 1.0),
+    ) -> None:
+        """Add annotation boxes to the visualization.
+
+        Args:
+            labels: List of annotation labels
+            patch_start: Start time of the patch
+            patch_end: End time of the patch
+            axarr: Matplotlib axes to draw on
+            offset: Offset for box drawing (default: 0.2)
+            color: RGB color tuple for the boxes
+        """
+        for row in labels:
+            bt, et, lf, hf, dur, fn, tags, notes, tag1, tag2, score, raven_file = dataclasses.astuple(row)
+            if et < patch_start:
+                continue
+            if bt > patch_end:
+                continue
+            xy = (bt - patch_start - offset, lf - 5)
+            width = et - bt + offset * 2
+            height = hf - lf + 10
+
+            for linewidth, edgecolor in [(3, (0, 0, 0)), (1, color)]:
+                rect = patches.Rectangle(
+                    xy,
+                    width,
+                    height,
+                    linewidth=linewidth,
+                    edgecolor=edgecolor,
+                    facecolor="none",
+                )
+                axarr.add_patch(rect)
+
+    def _normalize_spectral_power(
+        self,
+        np_spectral_power: np.ndarray,
+        try_per_channel_normalization: bool,  # noqa: FBT001
+        clip_outliers: bool,  # noqa: FBT001
+    ) -> np.ndarray:  # FBT001
+        if try_per_channel_normalization:
+            median_pwr_per_spectral_band = np.median(np_spectral_power, axis=1)
+            np_spectral_power = np_spectral_power / median_pwr_per_spectral_band[:, None]
+
+        if clip_outliers:
+            noise_floor = np.percentile(np_spectral_power, 0.1)
+            clip_level = np.percentile(np_spectral_power, 99.9)
+            db_normalized = np_spectral_power
+            db_normalized[np_spectral_power < noise_floor] = noise_floor
+            db_normalized[np_spectral_power > clip_level] = clip_level
+            np_spectral_power = db_normalized
+
+        return np_spectral_power
+
+    def _compute_color_channels(
+        self, stretched_similarity: torch.Tensor, stretched_dissimilarity: torch.Tensor, colormap: str = "bright"
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if colormap == "clean":
+            nearness = stretched_similarity
+            farness = stretched_dissimilarity
+
+            sim = nearness - farness
+            sim /= sim.abs().max()
+            sim = sim.numpy()
+
+            redness = -sim * 8 + 1
+            redness[redness > 1] = 1
+            redness[redness < 0] = 0
+
+            greenness = sim * 8 + 1
+            greenness[greenness > 1] = 1
+            greenness[greenness < 0] = 0
+
+        elif colormap == "bright":
+            nearness = stretched_similarity
+            farness = stretched_dissimilarity
+
+            sim = nearness - farness
+            sim /= sim.abs().max()
+            sim = sim.numpy()
+
+            # Create a smooth transition from red to yellow to green
+            # When sim is -1, we want red (1,0,0)
+            # When sim is 0, we want yellow (1,1,0)
+            # When sim is 1, we want green (0,1,0)
+
+            redness = np.clip(-sim + 1, 0, 1)
+            greenness = np.clip(sim + 1, 0, 1)
+
+        else:
+            redness = stretched_dissimilarity.numpy()
+            greenness = stretched_similarity.numpy()
+            if redness.max() > 1 or redness.min() < 0 or greenness.max() > 1 or greenness.min() < 0:
+                redness -= redness.min()
+                redness /= redness.max()
+                greenness -= greenness.min()
+                greenness /= greenness.max()
+
+        blueness = 1 - (redness + greenness)
+        blueness[blueness < 0] = 0
+        return redness, greenness, blueness
+
+    def plot_spectrogram(self, ax: Axes) -> None:
+        np_spectral_power = self._normalize_spectral_power(
+            self.spectral_power, self.try_per_channel_normalization, self.clip_outliers
+        )
+        s_db = librosa.power_to_db(np_spectral_power, ref=np.max)
+        # component["similarity"] = self.similarity_scores
+        # component["dissimilarity"] = self.dissimilarity_scores
+
+        if self.similarity_scores is not None and self.dissimilarity_scores is not None:
+            start_index = int(self.time_to_score_index(self.start_time))
+            end_index = int(self.time_to_score_index(self.end_time))
+            similarity = self.similarity_scores[start_index:end_index].clone()
+            dissimilarity = self.dissimilarity_scores[start_index:end_index].clone()
+
+            mx, mn = np.max(s_db), np.min(s_db)
+            normed = (s_db - mn) / (mx - mn)
+            s_db_rgb = np.stack((normed, normed, normed), axis=-1)
+
+            stretched_similarity = self.interpolate_1d_tensor(similarity, self.spec.shape[1])
+            stretched_dissimilarity = self.interpolate_1d_tensor(dissimilarity, self.spec.shape[1])
+
+            redness, greenness, blueness = self._compute_color_channels(
+                stretched_similarity, stretched_dissimilarity, self.colormap
+            )
+
+            s_db_rgb[:, :, 0] = s_db_rgb[:, :, 0] * redness
+            s_db_rgb[:, :, 1] = s_db_rgb[:, :, 1] * greenness
+            s_db_rgb[:, :, 2] = s_db_rgb[:, :, 2] * blueness
+
+            librosa.display.specshow(
+                s_db_rgb[:, :],
+                sr=self.sr,
+                n_fft=self.n_fft,
+                hop_length=self.hop_length,
+                x_axis="time",
+                y_axis="log" if self.log_scale else "linear",
+                y_coords=self.freqs,
+                ax=ax,
+            )
+        else:
+            librosa.display.specshow(
+                s_db,
+                sr=self.sr,
+                n_fft=self.n_fft,
+                hop_length=self.hop_length,
+                x_axis="time",
+                y_axis="log" if self.log_scale else "linear",
+                y_coords=self.freqs,
+                ax=ax,
+            )
+
+        ax.set_xticks(np.arange(0, self.duration + 1, 30))
+
+        if self.labels:
+            self.add_annotation_boxes(self.labels, self.start_time, self.end_time, ax, offset=0.5, color=(0, 1, 1))
+        if self.negative_labels:
+            self.add_annotation_boxes(
+                self.negative_labels, self.start_time, self.end_time, ax, offset=0.5, color=(0, 0, 1)
+            )
+
+
 class AudioFileVisualizer:
     def __init__(
         self,
@@ -26,18 +249,6 @@ class AudioFileVisualizer:
         class_probabilities: torch.Tensor | None = None,
         class_labels: list[str] | None = None,
     ) -> None:
-        """Initialize the AudioFileVisualizer.
-
-        Args:
-            audio_file: Path to audio file to visualize
-            start_time: Start time in seconds to load from
-            end_time: End time in seconds to load until (default: entire file)
-            n_fft: Size of FFT window
-            sr: Sample rate to load audio at
-            feature_rate: Rate of features in Hz (default: sr/320)
-            class_probabilities: Tensor of shape (num_features, num_classes) containing class probabilities
-            class_labels: List of class names corresponding to probabilities
-        """
         self.logger = logging.getLogger(__name__)
 
         # Load audio
@@ -47,22 +258,22 @@ class AudioFileVisualizer:
         self.duration = self.audio.shape[0] / self.sr
         self.audio_duration = self.audio.shape[0] / self.sr
 
-        # Compute spectral features
-        self.n_fft = n_fft
-        self.hop_length = self.n_fft // 4
-
         # Default for AVES/HuBERT embeddings
         # from https://arxiv.org/pdf/2106.07447
         self.feature_rate = self.sr // 320 if feature_rate is None else feature_rate
-
-        # Compute STFT and spectral power
-        self.spec = librosa.stft(self.audio, n_fft=self.n_fft, win_length=self.n_fft, hop_length=self.hop_length)
-        self.freqs = librosa.fft_frequencies(sr=self.sr, n_fft=self.n_fft)
-        self.spectral_power = np.abs(self.spec) ** 2  # type: ignore
-
-        # Store class probabilities and labels
         self.class_probabilities = class_probabilities
         self.class_labels = class_labels
+
+        # Compute spectral features
+        self.spectrogram_component = _SpectrogramComponent(
+            y=self.audio,
+            sr=self.sr,
+            class_probabilities=class_probabilities,
+            feature_rate=feature_rate,
+            target_class=0,
+            n_fft=n_fft,
+            hop_length=n_fft // 4,
+        )
 
         # Initialize plot components
         self.plot_components = []
@@ -125,75 +336,6 @@ class AudioFileVisualizer:
                 )
                 axarr.add_patch(rect)
 
-    def _normalize_spectral_power(
-        self,
-        np_spectral_power: np.ndarray,
-        try_per_channel_normalization: bool,  # noqa FBT001
-        clip_outliers: bool,  # noqa FBT001
-    ) -> np.ndarray:  # FBT001
-        if try_per_channel_normalization:
-            median_pwr_per_spectral_band = np.median(np_spectral_power, axis=1)
-            np_spectral_power = np_spectral_power / median_pwr_per_spectral_band[:, None]
-
-        if clip_outliers:
-            noise_floor = np.percentile(np_spectral_power, 0.1)
-            clip_level = np.percentile(np_spectral_power, 99.9)
-            db_normalized = np_spectral_power
-            db_normalized[np_spectral_power < noise_floor] = noise_floor
-            db_normalized[np_spectral_power > clip_level] = clip_level
-            np_spectral_power = db_normalized
-
-        return np_spectral_power
-
-    def _compute_color_channels(
-        self, stretched_similarity: torch.Tensor, stretched_dissimilarity: torch.Tensor, colormap: str
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        colormap = "bright"
-        if colormap == "clean":
-            nearness = stretched_similarity
-            farness = stretched_dissimilarity
-
-            sim = nearness - farness
-            sim /= sim.abs().max()
-            sim = sim.numpy()
-
-            redness = -sim * 8 + 1
-            redness[redness > 1] = 1
-            redness[redness < 0] = 0
-
-            greenness = sim * 8 + 1
-            greenness[greenness > 1] = 1
-            greenness[greenness < 0] = 0
-
-        elif colormap == "bright":
-            nearness = stretched_similarity
-            farness = stretched_dissimilarity
-
-            sim = nearness - farness
-            sim /= sim.abs().max()
-            sim = sim.numpy()
-
-            # Create a smooth transition from red to yellow to green
-            # When sim is -1, we want red (1,0,0)
-            # When sim is 0, we want yellow (1,1,0)
-            # When sim is 1, we want green (0,1,0)
-
-            redness = np.clip(-sim + 1, 0, 1)
-            greenness = np.clip(sim + 1, 0, 1)
-
-        else:
-            redness = stretched_dissimilarity.numpy()
-            greenness = stretched_similarity.numpy()
-            if redness.max() > 1 or redness.min() < 0 or greenness.max() > 1 or greenness.min() < 0:
-                redness -= redness.min()
-                redness /= redness.max()
-                greenness -= greenness.min()
-                greenness /= greenness.max()
-
-        blueness = 1 - (redness + greenness)
-        blueness[blueness < 0] = 0
-        return redness, greenness, blueness
-
     def setup_plot(
         self, title: str, save_file: str, start_time: float, end_time: float, width: float, height: float
     ) -> None:
@@ -209,28 +351,10 @@ class AudioFileVisualizer:
     def add_waveform(self) -> None:
         self.plot_components.append("waveform")
 
-    def add_spectrogram(
-        self,
-        labels: list | None = None,
-        negative_labels: list | None = None,
-        try_per_channel_normalization: bool = True,  # noqa FBT001 FBT002
-        clip_outliers: bool = True,  # noqa FBT001 FBT002
-        similarity_scoresz: torch.Tensor | None = None,
-        dissimilarity_scoresz: torch.Tensor | None = None,
-        colormap: str = "raw",
-        log_scale: bool = False,  # noqa FBT001 FBT002
-    ) -> None:  # FBT001
+    def add_spectrogram(self) -> None:  # FBT001
         self.plot_components.append(
             {
                 "type": "spectrogram",
-                "labels": labels or [],
-                "negative_labels": negative_labels or [],
-                "normalize": try_per_channel_normalization,
-                "clip_outliers": clip_outliers,
-                "similarity": similarity_scoresz,
-                "dissimilarity": dissimilarity_scoresz,
-                "colormap": colormap,
-                "log_scale": log_scale,
             }
         )
 
@@ -251,66 +375,6 @@ class AudioFileVisualizer:
         ax.set_ylabel("Amplitude")
         ax.set_xlim(0, self.duration)
         ax.set_xticks(np.arange(0, self.duration + 1, 30))
-
-    def _plot_spectrogram(self, ax: Axes, component: dict) -> None:
-        np_spectral_power = self._normalize_spectral_power(
-            self.spectral_power, component["normalize"], component["clip_outliers"]
-        )
-        s_db = librosa.power_to_db(np_spectral_power, ref=np.max)
-
-        if component["similarity"] is not None and component["dissimilarity"] is not None:
-            start_index = int(self.time_to_score_index(self.start_time))
-            end_index = int(self.time_to_score_index(self.end_time))
-            similarity = component["similarity"][start_index:end_index].clone()
-            dissimilarity = component["dissimilarity"][start_index:end_index].clone()
-
-            mx, mn = np.max(s_db), np.min(s_db)
-            normed = (s_db - mn) / (mx - mn)
-            s_db_rgb = np.stack((normed, normed, normed), axis=-1)
-
-            stretched_similarity = self.interpolate_1d_tensor(similarity, self.spec.shape[1])
-            stretched_dissimilarity = self.interpolate_1d_tensor(dissimilarity, self.spec.shape[1])
-
-            redness, greenness, blueness = self._compute_color_channels(
-                stretched_similarity, stretched_dissimilarity, component["colormap"]
-            )
-
-            s_db_rgb[:, :, 0] = s_db_rgb[:, :, 0] * redness
-            s_db_rgb[:, :, 1] = s_db_rgb[:, :, 1] * greenness
-            s_db_rgb[:, :, 2] = s_db_rgb[:, :, 2] * blueness
-
-            librosa.display.specshow(
-                s_db_rgb[:, :],
-                sr=self.sr,
-                n_fft=self.n_fft,
-                hop_length=self.hop_length,
-                x_axis="time",
-                y_axis="log" if component["log_scale"] else "linear",
-                y_coords=self.freqs,
-                ax=ax,
-            )
-        else:
-            librosa.display.specshow(
-                s_db,
-                sr=self.sr,
-                n_fft=self.n_fft,
-                hop_length=self.hop_length,
-                x_axis="time",
-                y_axis="log" if component["log_scale"] else "linear",
-                y_coords=self.freqs,
-                ax=ax,
-            )
-
-        ax.set_xticks(np.arange(0, self.duration + 1, 30))
-
-        if component["labels"]:
-            self.add_annotation_boxes(
-                component["labels"], self.start_time, self.end_time, ax, offset=0.5, color=(0, 1, 1)
-            )
-        if component["negative_labels"]:
-            self.add_annotation_boxes(
-                component["negative_labels"], self.start_time, self.end_time, ax, offset=0.5, color=(0, 0, 1)
-            )
 
     def _plot_similarities(self, ax: Axes, component: dict) -> None:
         start_index = int(self.time_to_score_index(self.start_time))
@@ -352,21 +416,9 @@ class AudioFileVisualizer:
         ax.set_xticks(np.arange(0, self.duration + 1, 30))
 
     def _get_tick_interval(self, duration: float) -> float:
-        """Calculate appropriate tick interval based on duration."""
-        if duration <= 10:  # For very short clips # noqa PLR2004
-            return 1  # One tick per second # PLR2004
-        elif duration <= 60:  # Up to 1 minute # noqa PLR2004
-            return 5  # Tick every 5 seconds # PLR2004
-        elif duration <= 300:  # Up to 5 minutes # noqa PLR2004
-            return 30  # Tick every 30 seconds   # PLR2004
-        elif duration <= 3600:  # Up to 1 hour # noqa PLR2004
-            return 300  # Tick every 5 minutes # PLR2004
-        elif duration <= 7200:  # Up to 2 hours # noqa PLR2004
-            return 600  # Tick every 10 minutes # PLR2004
-        elif duration <= 86400:  # Up to 24 hours # noqa PLR2004
-            return 3600  # Tick every hour # PLR2004
-        else:  # More than 24 hours # PLR2004
-            return 7200  # Tick every 2 hours # PLR2004
+        """Calculate appropriate human-friendly tick interval based on duration."""
+        intervals = {10: 1, 60: 5, 300: 30, 3600: 300, 7200: 600, 86400: 3600}
+        return next((v for k, v in intervals.items() if duration <= k), 7200)
 
     def generate_plot(self) -> None:
         plt.ioff()
@@ -390,15 +442,14 @@ class AudioFileVisualizer:
             if component == "waveform":
                 self._plot_waveform(ax)
             elif component.get("type") == "spectrogram":
-                self._plot_spectrogram(ax, component)
+                self.spectrogram_component.plot_spectrogram(ax)
             elif component.get("type") == "similarities":
                 self._plot_similarities(ax, component)
             elif component.get("type") == "class_probabilities":
-                self._plot_class_probabilities(ax, component)
-                # self._plot_class_probability_lines(ax, component)
+                self._plot_class_probabilities(ax)
+                # self._plot_class_probability_lines(ax)
 
-        # Enable x-axis ticks and labels for all subplots
-        for ax in self.axes:
+        for ax in self.axes[-1:-1]:
             ax.tick_params(axis="x", which="both", bottom=True, top=False, labelbottom=True)
             ax.set_xlabel("Time")
 
@@ -428,28 +479,19 @@ class AudioFileVisualizer:
         end_time: float = 60 * 6,
         height: float = 1280 / 100,
         width: float = 1920 / 100,
-        colormap: str = "raw",
-        labels: list | None = None,
-        negative_labels: list | None = None,
-        try_per_channel_normalization_on_power: bool = True,  # noqa FBT001
-        clip_outliers: bool = True,  # noqa FBT001
-        log_scale: bool = False,  # noqa FBT001
+        _colormap: str = "raw",
+        _labels: list | None = None,
+        _negative_labels: list | None = None,
+        _try_per_channel_normalization_on_power: bool = True,  # noqa: FBT001 FBT002
+        _clip_outliers: bool = True,  # noqa: FBT001 FBT002
+        _log_scale: bool = False,  # noqa: FBT001 FBT002
     ) -> None:
         # For backwards compatibility
         if end_time is None:
             end_time = self.duration
         self.setup_plot(title, save_file, start_time, end_time, width, height)
         self.add_waveform()
-        self.add_spectrogram(
-            labels,
-            negative_labels,
-            try_per_channel_normalization_on_power,
-            clip_outliers,
-            similarity_scoresz,
-            dissimilarity_scoresz,
-            colormap,
-            log_scale,
-        )
+        self.add_spectrogram()
         self.add_similarities(similarity_scoresz, dissimilarity_scoresz)
         if self.class_probabilities is not None:
             self.add_class_probabilities()
@@ -462,7 +504,7 @@ if __name__ == "__main__":
 
     import audio_classifier_visualizer as acv
 
-    audio_path = "/tmp/test.wav"  # noqa S108
+    audio_path = "/tmp/test.wav"  # noqa: S108
 
     y, sr = librosa.load(audio_path, sr=None, duration=60 * 5)
     expected_embedding_length = y.shape[0] // 320
@@ -484,7 +526,7 @@ if __name__ == "__main__":
 
     afv.visualize_audio_file_fragment(
         "demo",
-        "/tmp/1.png",  # noqa S108
+        "/tmp/1.png",  # noqa: S108
         # audio_path,
         scores_yes,
         scores_no,
@@ -499,4 +541,4 @@ if __name__ == "__main__":
     import IPython.display as ipd
     from PIL import Image
 
-    ipd.display(Image.open("/tmp/1.png"))  # noqa S108
+    ipd.display(Image.open("/tmp/1.png"))  # noqa: S108


### PR DESCRIPTION
Prefer matplotlib imshow over librosa.display.specshow for multi-axis figures, because the latter overwrites too much matplotlib global state.
